### PR TITLE
dw: added clumsy 'click to sort' to columns

### DIFF
--- a/selectors.html
+++ b/selectors.html
@@ -137,6 +137,44 @@
         }
     }
 
+	function compareValues(a, b) {
+		// return -1/0/1 based on what you "know" a and b
+		// are here. Numbers, text, some custom case-insensitive
+		// and natural number ordering, etc. That's up to you.
+		// A typical "do whatever JS would do" is:
+		let A = a?.replace(/,/g,'');
+		let B = b?.replace(/,/g,'');
+		if (!isNaN(A) && !isNaN(B)) return A - B;
+		return (A<B) ? -1 : (A>B) ? 1 : 0;
+	}
+
+	function sortTable(colnum) {
+		// get all the rows in this table:
+		const table = document.querySelector(`tbody`);
+		const tbody = document.querySelector("#selectors tbody");
+		let rows = Array.from(document.querySelectorAll(`tr`));
+
+		// but ignore the heading row:
+		//rows = rows.slice(1);
+
+		// set up the queryselector for getting the indicated
+		// column from a row, so we can compare using its value:
+		let qs = `td:nth-child(${colnum})`;
+
+		// and then just... sort the rows:
+		rows.sort( (r1,r2) => {
+			// get each row's relevant column
+			let t1 = r1?.querySelector(qs);
+			let t2 = r2?.querySelector(qs);
+
+			// and then effect sorting by comparing their content:
+			return compareValues(t1?.textContent,t2?.textContent);
+		});
+
+		// and then the magic part that makes the sorting appear on-page:
+		rows.forEach(row => table.appendChild(row));
+	}
+
     async function init() {
         selectors = await loadData();
         update();
@@ -181,6 +219,10 @@
         font-variant: tabular-nums;
     }
 
+		.sortable {
+			cursor: pointer;
+		}
+
     th {
         vertical-align: bottom;
         text-align: left;
@@ -206,10 +248,10 @@
     <table id="selectors">
         <thead>
         <tr>
-            <th>Selector</th>
-            <th class="num">Count <span id="outof"></span></th>
-            <th class="num">Days <span class="s">since last pick</span></th>
-            <th class="num">Weeks <span class="s">since last pick</span></th>
+            <th class="sortable" onclick="sortTable(1)">Selector</th>
+            <th class="num sortable" onclick="sortTable(2)">Count <span id="outof"></span></th>
+            <th class="num sortable" onclick="sortTable(3)">Days <span class="s">since last pick</span></th>
+            <th class="num sortable" onclick="sortTable(4)">Weeks <span class="s">since last pick</span></th>
         </tr>
         </thead>
         <tbody></tbody>


### PR DESCRIPTION
This change allows one to click a column heading to sort by ASC.

This could be further jazzed-up to keep track of sort order in a new array, so that subsequent column clicks could sort DESC.

Left as an exercise.